### PR TITLE
Initial release of version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.3.1.0
 
-* Added `skipMessage` and `skipMessageIf` to `Data.Grib`, two
-  functions to easily skip unwanted GRIB messages in a file.
+* Added `skipMessage`, `skipMessageIf`, and `skipMessageIf_` to
+  `Data.Grib`, three functions to easily skip unwanted GRIB messages
+  in a file.
 
 
 ## 0.3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HGrib Change Log
 
+## 0.3.1.0
+
+* Added `skipMessage` and `skipMessageIf` to `Data.Grib`, two
+  functions to easily skip unwanted GRIB messages in a file.
+
+
 ## 0.3.0.0
 
 * Added a `GribIO` monad in `Data.Grib`, which is a higher-level

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HGrib
 
-[![Build Status](https://travis-ci.org/mjakob/hgrib.svg?branch=develop)](https://travis-ci.org/mjakob/hgrib)
+[![Build Status](https://travis-ci.org/mjakob/hgrib.svg?branch=master)](https://travis-ci.org/mjakob/hgrib)
 
 Unofficial bindings for [ECMWF][]'s [GRIB API][] library for reading
 and writing [WMO FM-92 GRIB][] edition 1 and edition 2 messages.

--- a/hgrib.cabal
+++ b/hgrib.cabal
@@ -30,6 +30,11 @@ source-repository head
   location:  https://github.com/mjakob/hgrib.git
   branch:    develop
 
+source-repository this
+  type:      git
+  location:  https://github.com/mjakob/hgrib.git
+  tag:       0.3.1.0
+
 library
   default-language:  Haskell2010
   hs-source-dirs:    src

--- a/hgrib.cabal
+++ b/hgrib.cabal
@@ -1,7 +1,7 @@
 -- Package description for HGrib.
 
 name:                hgrib
-version:             0.3.0.0
+version:             0.3.1.0
 synopsis:            Unofficial bindings for GRIB API
 description:
     Unofficial bindings to ECMWF's GRIB API library for reading WMO

--- a/src/Data/Grib.hs
+++ b/src/Data/Grib.hs
@@ -17,6 +17,7 @@ module Data.Grib ( -- *The GRIB Monad
                  , runGribIO_
                  , skipMessage
                  , skipMessageIf
+                 , skipMessageIf_
 
                    -- **Get values
                    --
@@ -104,6 +105,20 @@ skipMessageIf :: (a -> Bool)  -- ^a predicate that will be given the
               -> GribIO a     -- ^an action to perform
               -> GribIO a
 skipMessageIf p m = do { x <- m; when (p x) skipMessage; return x }
+
+-- |Like 'skipMessageIf', but discard the result of the action.
+--
+-- ==== __Examples__
+--
+-- Sum all grid points of the first vertical level in a GRIB message:
+--
+-- > runGribIO "test/stage/test_uuid.grib2" $ do
+-- >   skipMessageIf_ (/= 1) $ getLong "topLevel"
+-- >   fmap sum getValues
+skipMessageIf_ :: (a -> Bool)
+               -> GribIO a
+               -> GribIO ()
+skipMessageIf_ p m = do { x <- m; when (p x) skipMessage }
 
 -- A try that catches the SkipMessage exception.
 trySkipMessage :: IO a -> IO (Either SkipMessage a)

--- a/test/Data/GribSpec.hs
+++ b/test/Data/GribSpec.hs
@@ -38,7 +38,7 @@ spec = do
 
     it "should fail with any exception raised by the action" $
       runGribIO testUuidPath (liftIO $ throwIO NullPtrReturned)
-        `shouldThrow` isNullPtrReturned
+      `shouldThrow` isNullPtrReturned
 
   describe "runGribIO_" $ do
     it "should return unit" $
@@ -52,7 +52,7 @@ spec = do
 
     it "should fail with any exception raised by the action" $
       runGribIO_ testUuidPath (liftIO $ throwIO NullPtrReturned)
-        `shouldThrow` isNullPtrReturned
+      `shouldThrow` isNullPtrReturned
 
   describe "skipMessage" $
     it "should make runGribIO not return the result" $ do
@@ -64,49 +64,59 @@ spec = do
   describe "skipMessageIf" $
     it "should make runGribIO not return the result if the predicate is true" $
       runGribIO testUuidPath (skipMessageIf (== 1) $ getLong "topLevel")
-        `shouldReturn` [2]
+      `shouldReturn` [2]
+
+  describe "skipMessageIf_" $ do
+    it "should make runGribIO not return () if the predicate is true" $
+      runGribIO testUuidPath (skipMessageIf_ (== 1) $ getLong "topLevel")
+      `shouldReturn` [()]
+    it "should behave like in the documented example" $ do
+      runGribIO testUuidPath $ do
+        skipMessageIf_ (/= 1) $ getLong "topLevel"
+        fmap sum getValues
+      `shouldReturn` [31595.198486328125]
 
   describe "getDouble" $
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (getDouble "missingKey")
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
   describe "getLong" $
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (getLong "missingKey")
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
   describe "getString" $
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (getString "missingKey")
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
   describe "setDouble" $ do
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (setDouble "missingKey" 0)
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
     it "should fail with GribReadOnly if the key is read-only" $
       runGribIO_ testUuidPath (setDouble "referenceValue" 0)
-        `shouldThrow` isGribException GribReadOnly
+      `shouldThrow` isGribException GribReadOnly
 
   describe "setLong" $ do
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (setLong "missingKey" 0)
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
     it "should fail with GribReadOnly if the key is read-only" $
       runGribIO_ testUuidPath (setLong "getNumberOfValues" 0)
-        `shouldThrow` isGribException GribReadOnly
+      `shouldThrow` isGribException GribReadOnly
 
   describe "setString" $ do
     it "should fail with GribNotFound if the key does not exist" $
       runGribIO_ testUuidPath (setString "missingKey" "value")
-        `shouldThrow` isGribException GribNotFound
+      `shouldThrow` isGribException GribNotFound
 
     it "should fail with GribReadOnly if the key is read-only" $
       runGribIO_ testUuidPath (setString "referenceValue" "value")
-        `shouldThrow` isGribException GribReadOnly
+      `shouldThrow` isGribException GribReadOnly
 
   describe "getFilename" $
     it "should return the name of the file being read" $


### PR DESCRIPTION
Change log:
- Added `skipMessage`, `skipMessageIf`, and `skipMessageIf_` to `Data.Grib`, three functions to easily skip unwanted GRIB messages in a file.
